### PR TITLE
feat: WebSocketメッセージのレートリミット実装

### DIFF
--- a/srv/ratelimit.go
+++ b/srv/ratelimit.go
@@ -1,0 +1,129 @@
+package srv
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimitConfig defines per-message-type rate limits.
+type RateLimitConfig struct {
+	// Rate is the number of tokens added per second.
+	Rate float64
+	// Burst is the maximum number of tokens (bucket capacity).
+	Burst int
+}
+
+// Default rate limit configurations per message type.
+var defaultRateLimits = map[string]RateLimitConfig{
+	// Game actions: relatively strict
+	"answer":             {Rate: 1, Burst: 3},
+	"vote":               {Rate: 1, Burst: 3},
+	"challenge":          {Rate: 0.5, Burst: 2},
+	"rebuttal":           {Rate: 0.5, Burst: 2},
+	"withdraw_challenge": {Rate: 0.5, Burst: 2},
+
+	// Room management: moderate
+	"create_room": {Rate: 0.5, Burst: 2},
+	"join":        {Rate: 0.5, Burst: 3},
+	"leave_room":  {Rate: 1, Burst: 3},
+	"start_game":  {Rate: 0.5, Burst: 2},
+
+	// Read-only / lightweight: generous
+	"get_rooms":  {Rate: 2, Burst: 5},
+	"get_genres": {Rate: 2, Burst: 5},
+	"ping":       {Rate: 2, Burst: 5},
+}
+
+// globalRateLimit applies to all messages regardless of type.
+var globalRateLimit = RateLimitConfig{Rate: 10, Burst: 20}
+
+// tokenBucket implements the token bucket algorithm.
+type tokenBucket struct {
+	tokens    float64
+	max       float64
+	rate      float64
+	lastCheck time.Time
+}
+
+// newTokenBucket creates a new token bucket starting full.
+func newTokenBucket(rate float64, burst int) *tokenBucket {
+	return &tokenBucket{
+		tokens:    float64(burst),
+		max:       float64(burst),
+		rate:      rate,
+		lastCheck: time.Now(),
+	}
+}
+
+// allow checks if a token is available and consumes one if so.
+func (tb *tokenBucket) allow() bool {
+	now := time.Now()
+	elapsed := now.Sub(tb.lastCheck).Seconds()
+	tb.lastCheck = now
+
+	// Add tokens based on elapsed time
+	tb.tokens += elapsed * tb.rate
+	if tb.tokens > tb.max {
+		tb.tokens = tb.max
+	}
+
+	if tb.tokens >= 1 {
+		tb.tokens--
+		return true
+	}
+	return false
+}
+
+// ConnectionRateLimiter manages rate limits for a single WebSocket connection.
+type ConnectionRateLimiter struct {
+	mu      sync.Mutex
+	global  *tokenBucket
+	buckets map[string]*tokenBucket
+	// Track consecutive violations for escalating response
+	violations int
+}
+
+// NewConnectionRateLimiter creates a rate limiter for one connection.
+func NewConnectionRateLimiter() *ConnectionRateLimiter {
+	return &ConnectionRateLimiter{
+		global:  newTokenBucket(globalRateLimit.Rate, globalRateLimit.Burst),
+		buckets: make(map[string]*tokenBucket),
+	}
+}
+
+// Allow checks if the given message type is allowed under rate limits.
+// Returns (allowed bool, shouldDisconnect bool).
+func (rl *ConnectionRateLimiter) Allow(msgType string) (bool, bool) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	// Check global rate limit first
+	if !rl.global.allow() {
+		rl.violations++
+		return false, rl.violations >= 50
+	}
+
+	// Check per-type rate limit
+	config, ok := defaultRateLimits[msgType]
+	if !ok {
+		// Unknown message types get a strict default
+		config = RateLimitConfig{Rate: 1, Burst: 2}
+	}
+
+	bucket, exists := rl.buckets[msgType]
+	if !exists {
+		bucket = newTokenBucket(config.Rate, config.Burst)
+		rl.buckets[msgType] = bucket
+	}
+
+	if !bucket.allow() {
+		rl.violations++
+		return false, rl.violations >= 50
+	}
+
+	// Reset violations on successful request
+	if rl.violations > 0 {
+		rl.violations--
+	}
+	return true, false
+}

--- a/srv/ratelimit_test.go
+++ b/srv/ratelimit_test.go
@@ -1,0 +1,112 @@
+package srv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenBucket_BasicAllow(t *testing.T) {
+	tb := newTokenBucket(10, 3) // 10/sec, burst 3
+	// Should allow up to burst
+	for i := 0; i < 3; i++ {
+		if !tb.allow() {
+			t.Fatalf("expected allow on request %d", i)
+		}
+	}
+	// 4th should be denied
+	if tb.allow() {
+		t.Fatal("expected deny after burst exhausted")
+	}
+}
+
+func TestTokenBucket_Refill(t *testing.T) {
+	tb := newTokenBucket(10, 3)
+	// Exhaust
+	for i := 0; i < 3; i++ {
+		tb.allow()
+	}
+	// Wait for refill (100ms = 1 token at 10/sec)
+	time.Sleep(150 * time.Millisecond)
+	if !tb.allow() {
+		t.Fatal("expected allow after refill")
+	}
+}
+
+func TestConnectionRateLimiter_AllowNormal(t *testing.T) {
+	rl := NewConnectionRateLimiter()
+	// Normal usage should be allowed
+	for i := 0; i < 5; i++ {
+		allowed, disconnect := rl.Allow("get_rooms")
+		if !allowed {
+			t.Fatalf("expected allow on request %d", i)
+		}
+		if disconnect {
+			t.Fatal("unexpected disconnect")
+		}
+	}
+}
+
+func TestConnectionRateLimiter_PerTypeLimit(t *testing.T) {
+	rl := NewConnectionRateLimiter()
+	// answer: burst=3, so 4th should be denied
+	for i := 0; i < 3; i++ {
+		allowed, _ := rl.Allow("answer")
+		if !allowed {
+			t.Fatalf("expected allow on answer %d", i)
+		}
+	}
+	allowed, _ := rl.Allow("answer")
+	if allowed {
+		t.Fatal("expected deny on answer after burst")
+	}
+}
+
+func TestConnectionRateLimiter_GlobalLimit(t *testing.T) {
+	rl := NewConnectionRateLimiter()
+	// Global burst is 20; exhaust it with mixed types
+	denied := false
+	for i := 0; i < 30; i++ {
+		allowed, _ := rl.Allow("ping")
+		if !allowed {
+			denied = true
+			break
+		}
+	}
+	if !denied {
+		t.Fatal("expected global rate limit to kick in")
+	}
+}
+
+func TestConnectionRateLimiter_DisconnectOnExcessiveViolations(t *testing.T) {
+	rl := NewConnectionRateLimiter()
+	// Exhaust per-type burst first
+	for i := 0; i < 3; i++ {
+		rl.Allow("answer")
+	}
+	// Now spam to accumulate violations
+	disconnected := false
+	for i := 0; i < 100; i++ {
+		_, shouldDisconnect := rl.Allow("answer")
+		if shouldDisconnect {
+			disconnected = true
+			break
+		}
+	}
+	if !disconnected {
+		t.Fatal("expected disconnect after excessive violations")
+	}
+}
+
+func TestConnectionRateLimiter_UnknownType(t *testing.T) {
+	rl := NewConnectionRateLimiter()
+	// Unknown types get strict default (burst=2)
+	allowed1, _ := rl.Allow("unknown_type")
+	allowed2, _ := rl.Allow("unknown_type")
+	allowed3, _ := rl.Allow("unknown_type")
+	if !allowed1 || !allowed2 {
+		t.Fatal("expected first 2 unknown type messages to be allowed")
+	}
+	if allowed3 {
+		t.Fatal("expected 3rd unknown type message to be denied")
+	}
+}


### PR DESCRIPTION
## 概要
Issue #27 の対応。WebSocket接続ごとにトークンバケット方式のレートリミットを実装し、スパム送信によるサーバー負荷やゲームの不公正を防止。

## 変更内容

### 新規ファイル
- `srv/ratelimit.go` - トークンバケット方式のレートリミッター
- `srv/ratelimit_test.go` - ユニットテスト (7テスト)

### 変更ファイル
- `srv/ws.go` - `WSConn` に `rateLimiter` フィールド追加、`readLoop` でメッセージ処理前にレートリミットチェック

## 設計

### 操作タイプ別レート制限

| カテゴリ | メッセージタイプ | レート | バースト |
|---|---|---|---|
| ゲーム操作 | `answer`, `vote` | 1/s | 3 |
| ゲーム操作 | `challenge`, `rebuttal`, `withdraw_challenge` | 0.5/s | 2 |
| ルーム管理 | `create_room`, `join`, `start_game` | 0.5/s | 2-3 |
| 読み取り系 | `get_rooms`, `get_genres`, `ping` | 2/s | 5 |
| **グローバル** | 全メッセージ共通 | 10/s | 20 |

### エスカレーション
- **制限超過時**: エラーメッセージを返しメッセージを無視
- **50回連続違反**: 接続を強制切断（DoS対策）

## テスト
- トークンバケットの基本動作・リフィル
- 接続レートリミッターの正常許可・タイプ別制限・グローバル制限
- 連続違反時の切断判定
- 未知メッセージタイプのデフォルト制限

Closes #27